### PR TITLE
Avoid a SIGSEGV when used within the cmsd.

### DIFF
--- a/src/XrdHdfs.cc
+++ b/src/XrdHdfs.cc
@@ -817,7 +817,10 @@ int XrdHdfsSys::Stat(const  char    *path,    // In
    }
 
 // Get the security name, and connect with it
-   const char* sec_name = ExtractAuthName(*client);
+//   When the cmsd uses this class, client is NULL.  Within the cmsd
+//   network, things should act as the superuser -- but only for 'stat'
+//   (not Open or OpenDir - those should remain 'nobody'!).
+   const char* sec_name = client ? ExtractAuthName(*client) : "root";
    hdfsFS fs = hadoop_connect("default", 0, sec_name);
    if (fs == NULL) {
       retc = XrdHdfsSys::Emsg(epname, error, EIO, "stat", fname);


### PR DESCRIPTION
The cmsd should act as a superuser with respect to 'Stat'ing the
files.

@djw8605 - this allows redirection to work with non-world-readable files.  Also fixes a null pointer deref.