### PR TITLE
Enable native HDFS libraries for xrootd-hdfs

### DIFF
--- a/spec/xrootd-hdfs.sysconfig
+++ b/spec/xrootd-hdfs.sysconfig
@@ -1,4 +1,5 @@
 HADOOP_CONF_DIR=/etc/hadoop/conf
+HADOOP_LIB_DIR=/usr/lib/hadoop
 #HADOOP_HOME=/usr/lib/hadoop-hdfs
 
 if [ -e $HADOOP_CONF_DIR/hadoop-env.sh ]; then
@@ -26,6 +27,10 @@ if [ "${LD_LIBRARY_PATH}" = "" ]; then
     export LD_LIBRARY_PATH=$f:${LD_LIBRARY_PATH}
   done
 fi
+
+# The native libraries contain heavily-optimized performance-critical routines (such as checksum algorithms)
+# SOFTWARE-2387
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_LIB_DIR/lib/native
 
 # Pulls all jars from hadoop client package and conf files from HADOOP_CONF_DIR
 for jar in ${HADOOP_HOME}/client/*.jar; do

--- a/spec/xrootd-hdfs.sysconfig
+++ b/spec/xrootd-hdfs.sysconfig
@@ -30,7 +30,7 @@ fi
 
 # The native libraries contain heavily-optimized performance-critical routines (such as checksum algorithms)
 # SOFTWARE-2387
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_LIB_DIR/lib/native
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HADOOP_LIB_DIR}/lib/native
 
 # Pulls all jars from hadoop client package and conf files from HADOOP_CONF_DIR
 for jar in ${HADOOP_HOME}/client/*.jar; do


### PR DESCRIPTION
I tested the change creating a mini hadoop cluster and firing an xrootd-server on top. Things still work I can xrdcp a file from hadoop:

```
xrdcp -f root://fermicloud114.fnal.gov:1094//tmp2/test-file .
[44B/44B][100%][==================================================][44B/s]  
```

Then I did an lsof, and verified that is now using the correct libraries:

```
[root@fermicloud114 ~]# lsof | grep /usr/lib/hadoop/lib/native
java       3607      hdfs  mem       REG              252,1    81680     313585 /usr/lib/hadoop/lib/native/libhadoop.so.1.0.0
xrootd    26004    xrootd  mem       REG              252,1    81680     313585 /usr/lib/hadoop/lib/native/libhadoop.so.1.0.0
```

@bbockelm, can you merge and tag this so I can proceed to build?
