### PR TITLE
Reuse HDFS FileSystem objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,30 +23,6 @@ SET( CMAKE_EXE_LINKER_FLAGS "-Wl,--no-undefined")
 
 include_directories("${HDFS_INCLUDES}" "${JVM_INCLUDES}" "${JVM_MD_INCLUDES}")
 
-# Test for the correct connect API.
-SET(ORIG_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
-SET(CMAKE_REQUIRED_INCLUDES ${HDFS_INCLUDES} ${JVM_INCLUDES} ${JVM_MD_INCLUDES} ${CMAKE_REQUIRED_INCLUDES} )
-SET(ORIG_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
-SET(CMAKE_REQUIRED_LIBRARIES "-L${JVM_LIB_DIR} -ljvm -L${HDFS_LIB_DIR} -lhdfs ${CMAKE_REQUIRED_LIBRARIES}")
-
-INCLUDE (CheckCSourceCompiles)
-check_c_source_compiles("
-#include \"hdfs.h\"
-int main() {
-    hdfsConnectAsUserNewInstance(\"default\", 0, \"nobody\");
-    return 0;
-}
-" HAVE_NEW_HDFS)
-
-SET(CMAKE_REQUIRED_LIBRARIES ${ORIG_CMAKE_REQUIRED_LIBRARIES})
-SET(CMAKE_REQUIRED_INCLUDES ${ORIG_CMAKE_REQUIRED_INCLUDES})
-
-if (HAVE_NEW_HDFS)
-  add_definitions(-DHADOOP_VERSION=20)
-else()
-  add_definitions(-DHADOOP_VERSION=19)
-endif()
-
 include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" )
 
 add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc)

--- a/spec/xrootd-hdfs.spec
+++ b/spec/xrootd-hdfs.spec
@@ -1,7 +1,6 @@
-
 Name: xrootd-hdfs
-Version: 1.8.7
-Release: 1%{?dist}
+Version: 1.9.0
+Release: 0%{?dist}
 Summary: HDFS plugin for xrootd
 
 Group: System Environment/Development
@@ -11,14 +10,14 @@ URL: https://github.com/bbockelm/xrootd-hdfs
 # git archive --format=tgz --prefix=%{name}-%{version}/ v%{version} > %{name}-%{version}.tar.gz
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires: xrootd-devel >= 1:4.1
-BuildRequires: xrootd-server-devel >= 1:4.1
+BuildRequires: xrootd-devel >= 1:4.6
+BuildRequires: xrootd-server-devel >= 1:4.6
 BuildRequires: cmake
 BuildRequires: hadoop-libhdfs >= 2.0.0+545-1.cdh4.1.1
 BuildRequires: java7-devel
 BuildRequires: jpackage-utils
 Requires: hadoop-client >= 2.0.0+545-1.cdh4.1.1
-Conflicts: xrootd < 3.0.3-1
+Conflicts: xrootd < 4.6.0-1
 
 %package devel
 Summary: Development headers for Xrootd HDFS plugin
@@ -71,14 +70,41 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/XrdHdfs.hh
 
 %changelog
+* Fri Mar 24 2017 Brian Bockelman <bbockelm@cse.unl.edu> - 1.9.0-1
+- Implement xrootd's autostat protocol.
+- Implement per-user connection caching.
+
+* Mon Feb 27 2017 Brian Bockelman <bbockelm@cse.unl.edu> - 1.8.8-2
+- Fix empty directory listing.
+
+* Thu Jul 21 2016 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.8-1
+- Use native libraries (SOFTWARE-2387)
+- Built from Brian's git repo
+
+* Thu Jul 21 2016 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.8-0.1
+- Use native libraries (SOFTWARE-2387)
+
+* Mon Feb 22 2016 Carl Edquist <edquist@cs.wisc.edu> - 1.8.7-2
+- Rebuild against hadoop-2.0.0+1612 (SOFTWARE-2161)
+
 * Wed Jan 20 2016 Carl Edquist <edquist@cs.wisc.edu> - 1.8.7-1
 - EL7 build fixes (SOFTWARE-2162)
 
-* Sat Jan 02 2016 Brian Bockelman <bbockelm@cse.unl.edu> - 1.8.6-1
+* Tue Jan 5 2016 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.6-1
 - Add support for non-world-readable files.
 
-* Thu Sep 25 2014 Brian Bockelman <bbockelm@cse.unl.edu> - 1.8.5-1
-- Add support for writes.
+-* Thu Sep 25 2014 Brian Bockelman <bbockelm@cse.unl.edu> - 1.8.5-1
+-- Add support for writes.
+
+* Tue Feb 24 2015 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.4-4
+- Remove xrootd-compat-libs not necessary
+- Removed xrootd4 requirements
+
+* Tue Feb 24 2015 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.4-3
+- Change requirements to xrootd and added xrootd-compat-libs
+
+* Thu Jul 10 2014 Edgar Fajardo <efajardo@physics.ucsd.edu> - 1.8.4-2
+- Recompiled using xrootd4 libraries.
 
 * Mon Apr 14 2014 Brian Bockelman <bbockelm@cse.unl.edu> - 1.8.4-1
 - Add Xrootd versioning information.

--- a/src/XrdHdfs.hh
+++ b/src/XrdHdfs.hh
@@ -42,6 +42,7 @@ public:
         int         Opendir(const char *dirName, XrdOucEnv &);
         int         Readdir(char *buff, int blen);
         int         Close(long long *retsz=0);
+        int         StatRet(struct stat *buff);
 
                     XrdHdfsDirectory(const char *tid=0);
 
@@ -56,6 +57,11 @@ int            dirPos;
 char          *fname;
 const char    *tident;
 int  isopen;
+
+// A pointer to the current entry in the directory; if set non-null, we
+// automatically populate this with the entry's "Stat" information.  This allows
+// Xrootd to save a corresponding call to `Stat` for each directory entry.
+struct stat *m_stat_buf;
 };
 
 /******************************************************************************/
@@ -204,6 +210,11 @@ int    ConfigProc(const char *);
 int    ConfigXeq(char *, XrdOucStream &);
 int    xnml(XrdOucStream &Config);
 
+// Static instance of the HDFS filesystem; this is used by the cmsd in order
+// to avoid opening / closing the filesystem repeatedly (reduces the number of
+// new connections to the namenode).
+static XrdSysMutex m_fs_mutex;
+static hdfsFS m_cmsd_fs;
 
 };
 #endif


### PR DESCRIPTION
This patchset caches and significant improves the speed of various filesystem callouts.  Particularly, one does not need to create a new connection to the NN for each operation -- and `readdir` operations automatically create the corresponding `stat` object (with no additional round trip to the NameNode).